### PR TITLE
fix: Generate ssh host keys on first boot

### DIFF
--- a/pishrink.sh
+++ b/pishrink.sh
@@ -315,8 +315,14 @@ fi
 if [[ $prep == true ]]; then
   info "Syspreping: Removing logs, apt archives, dhcp leases, ssh hostkeys and users bash history"
   mountdir=$(mktemp -d)
+
+  # Temporarily mount image to manipulate internal files
   mount "$loopback" "$mountdir"
+
+  # Remove unwanted cache, logs, sensitive data
   rm -rvf $mountdir/var/cache/apt/archives/* $mountdir/var/lib/dhcpcd5/* $mountdir/var/log/* $mountdir/var/tmp/* $mountdir/tmp/* $mountdir/etc/ssh/*_host_*
+
+  # Remove any user's bash session history
   find -E "$mountdir" -regex '.*/(home/.*|root)/\.bash_history[0-9]*' -type f -exec rm -vf {} \;
   find -E "$mountdir" -regex '.*/(home/.*|root)/\.bash_sessions' -type d -exec rm -vrf {} +;
 
@@ -324,6 +330,7 @@ if [[ $prep == true ]]; then
   ln -s /lib/systemd/system/regenerate_ssh_host_keys.service \
         "$mountdir/etc/systemd/system/multi-user.target.wants/regenerate_ssh_host_keys.service"
 
+  # unmount filesystem image
   umount "$mountdir"
 fi
 

--- a/pishrink.sh
+++ b/pishrink.sh
@@ -319,6 +319,11 @@ if [[ $prep == true ]]; then
   rm -rvf $mountdir/var/cache/apt/archives/* $mountdir/var/lib/dhcpcd5/* $mountdir/var/log/* $mountdir/var/tmp/* $mountdir/tmp/* $mountdir/etc/ssh/*_host_*
   find -E "$mountdir" -regex '.*/(home/.*|root)/\.bash_history[0-9]*' -type f -exec rm -vf {} \;
   find -E "$mountdir" -regex '.*/(home/.*|root)/\.bash_sessions' -type d -exec rm -vrf {} +;
+
+  # manually perform systemctl enable regenerate_ssh_host_keys.service
+  ln -s /lib/systemd/system/regenerate_ssh_host_keys.service \
+        "$mountdir/etc/systemd/system/multi-user.target.wants/regenerate_ssh_host_keys.service"
+
   umount "$mountdir"
 fi
 


### PR DESCRIPTION
fix the problem with using the `-p` option when it removes the SSH Host keys.  SSHD fails if host keys are not created and will not autogenerate them since the service is disabled after initial boot.